### PR TITLE
chore: Update databricks-zerobus-ingest-sdk to published crate v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ tokio-util = "0.7"
 futures = "0.3"
 
 # Databricks Zerobus SDK
-# Using release version v0.1.1 from GitHub
-# Repository: https://github.com/databricks/zerobus-sdk-rs
-databricks-zerobus-ingest-sdk = { git = "https://github.com/databricks/zerobus-sdk-rs.git", tag = "v0.1.1", package = "databricks-zerobus-ingest-sdk" }
+# Using published crate version from crates.io
+databricks-zerobus-ingest-sdk = "=0.1.0"
 
 # Arrow
 arrow = "57"


### PR DESCRIPTION
## Summary

Updates the `databricks-zerobus-ingest-sdk` dependency from a git dependency to the published crate on crates.io.

## Changes

- Change from git dependency (`git = "https://github.com/databricks/zerobus-sdk-rs.git", tag = "v0.1.1"`) to published crate
- Use exact version constraint (`=0.1.0`) for reproducible builds
- Update from git tag v0.1.1 to published version 0.1.0

## Benefits

- Improved dependency management and build reproducibility
- Uses published crate from crates.io instead of git repository
- Exact version constraint ensures consistent builds across environments

## Testing

- ✅ `cargo check` passes
- ✅ Dependency resolves correctly from crates.io
- ✅ Commit is GPG signed